### PR TITLE
This change adds evaluation calls for the client.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
 # OpenFeature SDK for Golang 
 
+[![Go Report Card](https://goreportcard.com/badge/github.com/open-feature/golang-sdk)](https://goreportcard.com/report/github.com/open-feature/golang-sdk)
+
 > :warning: This repository is a placeholder for a future SDK implementation.
 > It is not ready for evaluation

--- a/pkg/openfeature/client.go
+++ b/pkg/openfeature/client.go
@@ -1,0 +1,96 @@
+package openfeature
+
+type Client struct {
+	Name string
+}
+
+// GetClient returns a new Client.  Name is a unique identifier for this client
+func GetClient(name string) Client {
+	return Client{Name: name}
+}
+
+// AddHooks adds one or more hooks to the client
+func (c Client) AddHooks(hooks ...Hook) {
+
+}
+
+// Type represents the type of a flg
+type Type int64
+
+const (
+	Boolean Type = iota
+	String
+	Number
+	Object
+)
+
+type EvaluationDetails struct {
+	FlagKey  string
+	FlagType Type
+	ResolutionDetail
+}
+
+// GetBooleanValue return boolean evaluation for flag
+func (c Client) GetBooleanValue(flag string, defaultValue bool, evalCtx EvaluationContext, options ...EvaluationOption) (bool, error) {
+	resolution := api.provider.GetBooleanEvaluation(flag, defaultValue, evalCtx, options...)
+	return resolution.Value, resolution.Error()
+}
+
+// GetStringValue return string evaluation for flag
+func (c Client) GetStringValue(flag string, defaultValue string, evalCtx EvaluationContext, options ...EvaluationOption) (string, error) {
+	resolution := api.provider.GetStringEvaluation(flag, defaultValue, evalCtx, options...)
+	return resolution.Value, resolution.Error()
+}
+
+// GetNumberValue return number evaluation for flag
+func (c Client) GetNumberValue(flag string, defaultValue float64, evalCtx EvaluationContext, options ...EvaluationOption) (float64, error) {
+	resolution := api.provider.GetNumberEvaluation(flag, defaultValue, evalCtx, options...)
+	return resolution.Value, resolution.Error()
+}
+
+// GetObjectValue return object evaluation for flag
+func (c Client) GetObjectValue(flag string, defaultValue interface{}, evalCtx EvaluationContext, options ...EvaluationOption) (interface{}, error) {
+	resolution := api.provider.GetObjectEvaluation(flag, defaultValue, evalCtx, options...)
+	return resolution.Value, resolution.Error()
+}
+
+// GetBooleanValueDetails return boolean evaluation for flag
+func (c Client) GetBooleanValueDetails(flag string, defaultValue bool, evalCtx EvaluationContext, options ...EvaluationOption) (EvaluationDetails, error) {
+	resolution := api.provider.GetBooleanEvaluation(flag, defaultValue, evalCtx, options...)
+	return EvaluationDetails{
+		FlagKey:          flag,
+		FlagType:         Boolean,
+		ResolutionDetail: resolution.ResolutionDetail,
+	}, resolution.Error()
+
+}
+
+// GetStringValueDetails return string evaluation for flag
+func (c Client) GetStringValueDetails(flag string, defaultValue string, evalCtx EvaluationContext, options ...EvaluationOption) (EvaluationDetails, error) {
+	resolution := api.provider.GetStringEvaluation(flag, defaultValue, evalCtx, options...)
+	return EvaluationDetails{
+		FlagKey:          flag,
+		FlagType:         String,
+		ResolutionDetail: resolution.ResolutionDetail,
+	}, resolution.Error()
+}
+
+// GetNumberValueDetails return number evaluation for flag
+func (c Client) GetNumberValueDetails(flag string, defaultValue float64, evalCtx EvaluationContext, options ...EvaluationOption) (EvaluationDetails, error) {
+	resolution := api.provider.GetNumberEvaluation(flag, defaultValue, evalCtx, options...)
+	return EvaluationDetails{
+		FlagKey:          flag,
+		FlagType:         Number,
+		ResolutionDetail: resolution.ResolutionDetail,
+	}, resolution.Error()
+}
+
+// GetObjectValueDetails return object evaluation for flag
+func (c Client) GetObjectValueDetails(flag string, defaultValue interface{}, evalCtx EvaluationContext, options ...EvaluationOption) (EvaluationDetails, error) {
+	resolution := api.provider.GetObjectEvaluation(flag, defaultValue, evalCtx, options...)
+	return EvaluationDetails{
+		FlagKey:          flag,
+		FlagType:         Object,
+		ResolutionDetail: resolution,
+	}, resolution.Error()
+}

--- a/pkg/openfeature/evaluation_context.go
+++ b/pkg/openfeature/evaluation_context.go
@@ -3,5 +3,4 @@ package openfeature
 // EvaluationContext
 // https://github.com/open-feature/spec/blob/main/specification/evaluation-context/evaluation-context.md
 type EvaluationContext interface {
-
 }

--- a/pkg/openfeature/hooks.go
+++ b/pkg/openfeature/hooks.go
@@ -1,0 +1,13 @@
+package openfeature
+
+// Hook Hooks are a mechanism whereby application developers can add arbitrary behavior to flag evaluation. They operate similarly to middleware in many web frameworks.
+// https://github.com/open-feature/spec/blob/main/specification/flag-evaluation/hooks.md
+type Hook interface {
+
+}
+
+type HookContext struct {
+	flagKey string
+	flagType string
+
+}

--- a/pkg/openfeature/noop_provider.go
+++ b/pkg/openfeature/noop_provider.go
@@ -1,0 +1,51 @@
+package openfeature
+
+// NoopProvider implements the FeatureProvider interface and provides functions for evaluating flags
+type NoopProvider struct{}
+
+// Name returns the name of the provider
+func (e NoopProvider) Name() string {
+	return "NoopProvider"
+}
+
+// GetBooleanEvaluation returns a boolean flag.
+func (e NoopProvider) GetBooleanEvaluation(flag string, defaultValue bool, evalCtx EvaluationContext, options ...EvaluationOption) BoolResolutionDetail {
+	return BoolResolutionDetail{
+		Value: defaultValue,
+		ResolutionDetail: ResolutionDetail{
+			Variant: "default-variant",
+			Reason:  DEFAULT,
+		},
+	}
+}
+
+// GetStringEvaluation returns a string flag.
+func (e NoopProvider) GetStringEvaluation(flag string, defaultValue string, evalCtx EvaluationContext, options ...EvaluationOption) StringResolutionDetail {
+	return StringResolutionDetail{
+		Value: defaultValue,
+		ResolutionDetail: ResolutionDetail{
+			Variant: "default-variant",
+			Reason:  DEFAULT,
+		},
+	}
+}
+
+// GetNumberEvaluation returns a number flag.
+func (e NoopProvider) GetNumberEvaluation(flag string, defaultValue float64, evalCtx EvaluationContext, options ...EvaluationOption) NumberResolutionDetail {
+	return NumberResolutionDetail{
+		Value: defaultValue,
+		ResolutionDetail: ResolutionDetail{
+			Variant: "default-variant",
+			Reason:  DEFAULT,
+		},
+	}
+}
+
+// GetObjectEvaluation returns an object flag
+func (e NoopProvider) GetObjectEvaluation(flag string, defaultValue interface{}, evalCtx EvaluationContext, options ...EvaluationOption) ResolutionDetail {
+	return ResolutionDetail{
+		Value:   defaultValue,
+		Variant: "default-variant",
+		Reason:  DEFAULT,
+	}
+}

--- a/pkg/openfeature/noop_provider_test.go
+++ b/pkg/openfeature/noop_provider_test.go
@@ -1,0 +1,23 @@
+package openfeature
+
+import (
+	"testing"
+)
+
+func TestNoopProvider_Name(t *testing.T) {
+	tests := map[string]struct {
+		want string
+	}{
+		"Given a NOOP provider, then Name() will return NoopProvider": {
+			want: "NoopProvider",
+		},
+	}
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			e := NoopProvider{}
+			if got := e.Name(); got != tt.want {
+				t.Errorf("Name() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/openfeature/openfeature.go
+++ b/pkg/openfeature/openfeature.go
@@ -20,13 +20,7 @@ func init() {
 }
 
 // EvaluationOption should contain a list of hooks to be executed for a flag evaluation
-<<<<<<< Updated upstream
 type EvaluationOption interface {}
-
-
-
-=======
-type EvaluationOption interface{}
 
 func (api *evaluationAPI) setProvider(provider FeatureProvider) {
 	api.Lock()
@@ -38,4 +32,3 @@ func (api *evaluationAPI) setProvider(provider FeatureProvider) {
 func SetProvider(provider FeatureProvider) {
 	api.setProvider(provider)
 }
->>>>>>> Stashed changes

--- a/pkg/openfeature/openfeature.go
+++ b/pkg/openfeature/openfeature.go
@@ -1,7 +1,41 @@
 package openfeature
 
+import (
+	"sync"
+)
+
+type evaluationAPI struct {
+	provider FeatureProvider
+	sync.RWMutex
+}
+
+// api is the global evaluationAPI.  This is a singleton and there can only be one instance.
+var api evaluationAPI
+
+// init initializes the openfeature evaluation API
+func init() {
+	api = evaluationAPI{
+		provider: NoopProvider{},
+	}
+}
+
 // EvaluationOption should contain a list of hooks to be executed for a flag evaluation
+<<<<<<< Updated upstream
 type EvaluationOption interface {}
 
 
 
+=======
+type EvaluationOption interface{}
+
+func (api *evaluationAPI) setProvider(provider FeatureProvider) {
+	api.Lock()
+	defer api.Unlock()
+	api.provider = provider
+}
+
+// SetProvider sets the global provider.
+func SetProvider(provider FeatureProvider) {
+	api.setProvider(provider)
+}
+>>>>>>> Stashed changes

--- a/pkg/openfeature/openfeature_test.go
+++ b/pkg/openfeature/openfeature_test.go
@@ -1,0 +1,60 @@
+package openfeature_test
+
+import (
+	"encoding/json"
+	"fmt"
+	"log"
+
+	"github.com/open-feature/golang-sdk/pkg/openfeature"
+)
+
+func ExampleGetClient() {
+	client := openfeature.GetClient("example-client")
+	fmt.Printf("Client Name: %s", client.Name)
+	// Output: Client Name: example-client
+}
+
+func ExampleClient_GetBooleanValue() {
+	client := openfeature.GetClient("example-client")
+	value, err := client.GetBooleanValue("test-flag", true, nil)
+	if err != nil {
+		log.Fatal("error while getting boolean value : ", err)
+	}
+
+	fmt.Printf("test-flag value: %v", value)
+	// Output: test-flag value: true
+}
+
+func ExampleClient_GetStringValue() {
+	client := openfeature.GetClient("example-client")
+	value, err := client.GetStringValue("test-flag", "openfeature", nil)
+	if err != nil {
+		log.Fatal("error while getting string value : ", err)
+	}
+
+	fmt.Printf("test-flag value: %v", value)
+	// Output: test-flag value: openfeature
+}
+
+func ExampleClient_GetNumberValue() {
+	client := openfeature.GetClient("example-client")
+	value, err := client.GetNumberValue("test-flag", 0.55, nil)
+	if err != nil {
+		log.Fatal("error while getting number value : ", err)
+	}
+
+	fmt.Printf("test-flag value: %v", value)
+	// Output: test-flag value: 0.55
+}
+
+func ExampleClient_GetObjectValue() {
+	client := openfeature.GetClient("example-client")
+	value, err := client.GetObjectValue("test-flag", map[string]string{"foo": "bar"}, nil)
+	if err != nil {
+		log.Fatal("error while getting object value : ", err)
+	}
+
+	str, _ := json.Marshal(value)
+	fmt.Printf("test-flag value: %v", string(str))
+	// Output: test-flag value: {"foo":"bar"}
+}

--- a/pkg/openfeature/provider.go
+++ b/pkg/openfeature/provider.go
@@ -3,15 +3,12 @@ package openfeature
 import "errors"
 
 const (
-	DISABLED string = "disabled" // variant returned because feature is disabled
+	DISABLED        string = "disabled"     // variant returned because feature is disabled
 	TARGETING_MATCH string = "target match" // variant returned because matched target rule
-	DEFAULT string = "default" // variant returned the default
-	UNKNOWN string = "unknown" //variant returned for unknown reason
-	ERROR string = "error" // variant returned due to error
+	DEFAULT         string = "default"      // variant returned the default
+	UNKNOWN         string = "unknown"      //variant returned for unknown reason
+	ERROR           string = "error"        // variant returned due to error
 )
-
-
-
 
 // FeatureProvider interface defines a set of functions that can be called in order to evaluate a flag.
 // vendors should implement
@@ -29,10 +26,10 @@ type FeatureProvider interface {
 // N.B we could use generics but to support older versions of golang for now we will have type specific resolution
 // detail
 type ResolutionDetail struct {
-	Value interface{}
+	Value     interface{}
 	ErrorCode string
-	Reason string
-	Variant string
+	Reason    string
+	Variant   string
 }
 
 func (resolution ResolutionDetail) Error() error {
@@ -59,5 +56,3 @@ type NumberResolutionDetail struct {
 	Value float64
 	ResolutionDetail
 }
-
-

--- a/pkg/openfeature/provider.go
+++ b/pkg/openfeature/provider.go
@@ -1,5 +1,7 @@
 package openfeature
 
+import "errors"
+
 const (
 	DISABLED string = "disabled" // variant returned because feature is disabled
 	TARGETING_MATCH string = "target match" // variant returned because matched target rule
@@ -17,7 +19,7 @@ type FeatureProvider interface {
 	Name() string
 	GetBooleanEvaluation(flag string, defaultValue bool, evalCtx EvaluationContext, options ...EvaluationOption) BoolResolutionDetail
 	GetStringEvaluation(flag string, defaultValue string, evalCtx EvaluationContext, options ...EvaluationOption) StringResolutionDetail
-	GetNumberEvaluation(flag string, defaultValue int64, evalCtx EvaluationContext, options ...EvaluationOption) NumberResolutionDetail
+	GetNumberEvaluation(flag string, defaultValue float64, evalCtx EvaluationContext, options ...EvaluationOption) NumberResolutionDetail
 	GetObjectEvaluation(flag string, defaultValue interface{}, evalCtx EvaluationContext, options ...EvaluationOption) ResolutionDetail
 }
 
@@ -33,6 +35,13 @@ type ResolutionDetail struct {
 	Variant string
 }
 
+func (resolution ResolutionDetail) Error() error {
+	if resolution.ErrorCode == "" {
+		return nil
+	}
+	return errors.New(resolution.ErrorCode)
+}
+
 // BoolResolutionDetail provides a resolution detail with boolean type
 type BoolResolutionDetail struct {
 	Value bool
@@ -45,9 +54,9 @@ type StringResolutionDetail struct {
 	ResolutionDetail
 }
 
-// NumberResolutionDetail provides a resolution detail with in64 type
+// NumberResolutionDetail provides a resolution detail with float64 type
 type NumberResolutionDetail struct {
-	Value int64
+	Value float64
 	ResolutionDetail
 }
 

--- a/pkg/providers/noop.go
+++ b/pkg/providers/noop.go
@@ -1,0 +1,53 @@
+package providers
+
+import "github.com/open-feature/golang-sdk/pkg/openfeature"
+
+// NoopProvider implements the FeatureProvider interface and provides functions for evaluating flags
+type NoopProvider struct {}
+
+// Name returns the name of the provider
+func (e NoopProvider) Name() string {
+	return "NoopProvider"
+}
+
+// GetBooleanEvaluation returns a boolean flag.
+func (e NoopProvider) GetBooleanEvaluation(flag string, defaultValue bool, evalCtx openfeature.EvaluationContext, options ...openfeature.EvaluationOption) openfeature.BoolResolutionDetail {
+	return openfeature.BoolResolutionDetail{
+		Value: defaultValue,
+		ResolutionDetail: openfeature.ResolutionDetail{
+			Variant: "default-variant",
+			Reason: openfeature.DEFAULT,
+		},
+	}
+}
+
+// GetStringEvaluation returns a string flag.
+func (e NoopProvider) GetStringEvaluation(flag string, defaultValue string, evalCtx openfeature.EvaluationContext, options ...openfeature.EvaluationOption) openfeature.StringResolutionDetail {
+	return openfeature.StringResolutionDetail{
+		Value: defaultValue,
+		ResolutionDetail: openfeature.ResolutionDetail{
+			Variant: "default-variant",
+			Reason: openfeature.DEFAULT,
+		},
+	}
+}
+
+// GetNumberEvaluation returns a number flag.
+func (e NoopProvider) GetNumberEvaluation(flag string, defaultValue int64, evalCtx openfeature.EvaluationContext, options ...openfeature.EvaluationOption) openfeature.NumberResolutionDetail {
+	return openfeature.NumberResolutionDetail{
+		Value: defaultValue,
+		ResolutionDetail: openfeature.ResolutionDetail{
+			Variant: "default-variant",
+			Reason: openfeature.DEFAULT,
+		},
+	}
+}
+
+// GetObjectEvaluation returns an object flag
+func (e NoopProvider) GetObjectEvaluation(flag string, defaultValue interface{}, evalCtx openfeature.EvaluationContext, options ...openfeature.EvaluationOption) openfeature.ResolutionDetail {
+	return openfeature.ResolutionDetail{
+		Value: defaultValue,
+		Variant: "default-variant",
+		Reason: openfeature.DEFAULT,
+	}
+}


### PR DESCRIPTION
The Client can call Bool, String, Number, Evaluation functions and get
corrosponding flag value.

The OpenFeature API gets initalized automatically as a singleton.
By default it uses the noop provider but this can be overriden by
calling SetProvider.