### PR TITLE
Rename getters to be more inline with Golang idioms

### DIFF
--- a/pkg/openfeature/client.go
+++ b/pkg/openfeature/client.go
@@ -4,14 +4,14 @@ package openfeature
 type IClient interface {
 	Metadata() ClientMetadata
 	AddHooks(hooks ...Hook)
-	GetBooleanValue(flag string, defaultValue bool, evalCtx EvaluationContext, options ...EvaluationOption) (bool, error)
-	GetStringValue(flag string, defaultValue string, evalCtx EvaluationContext, options ...EvaluationOption) (string, error)
-	GetNumberValue(flag string, defaultValue float64, evalCtx EvaluationContext, options ...EvaluationOption) (float64, error)
-	GetObjectValue(flag string, defaultValue interface{}, evalCtx EvaluationContext, options ...EvaluationOption) (interface{}, error)
-	GetBooleanValueDetails(flag string, defaultValue bool, evalCtx EvaluationContext, options ...EvaluationOption) (EvaluationDetails, error)
-	GetStringValueDetails(flag string, defaultValue string, evalCtx EvaluationContext, options ...EvaluationOption) (EvaluationDetails, error)
-	GetNumberValueDetails(flag string, defaultValue float64, evalCtx EvaluationContext, options ...EvaluationOption) (EvaluationDetails, error)
-	GetObjectValueDetails(flag string, defaultValue interface{}, evalCtx EvaluationContext, options ...EvaluationOption) (EvaluationDetails, error)
+	BooleanValue(flag string, defaultValue bool, evalCtx EvaluationContext, options ...EvaluationOption) (bool, error)
+	StringValue(flag string, defaultValue string, evalCtx EvaluationContext, options ...EvaluationOption) (string, error)
+	NumberValue(flag string, defaultValue float64, evalCtx EvaluationContext, options ...EvaluationOption) (float64, error)
+	ObjectValue(flag string, defaultValue interface{}, evalCtx EvaluationContext, options ...EvaluationOption) (interface{}, error)
+	BooleanValueDetails(flag string, defaultValue bool, evalCtx EvaluationContext, options ...EvaluationOption) (EvaluationDetails, error)
+	StringValueDetails(flag string, defaultValue string, evalCtx EvaluationContext, options ...EvaluationOption) (EvaluationDetails, error)
+	NumberValueDetails(flag string, defaultValue float64, evalCtx EvaluationContext, options ...EvaluationOption) (EvaluationDetails, error)
+	ObjectValueDetails(flag string, defaultValue interface{}, evalCtx EvaluationContext, options ...EvaluationOption) (EvaluationDetails, error)
 }
 
 // ClientMetadata provides a client's metadata
@@ -27,14 +27,14 @@ func (cm ClientMetadata) Name() string {
 // Client implements the behaviour required of an openfeature client
 type Client struct {
 	metadata ClientMetadata
-	hooks []Hook
+	hooks    []Hook
 }
 
 // GetClient returns a new Client. Name is a unique identifier for this client
 func GetClient(name string) *Client {
 	return &Client{
 		metadata: ClientMetadata{name: name},
-		hooks: []Hook{},
+		hooks:    []Hook{},
 	}
 }
 
@@ -64,9 +64,9 @@ type EvaluationDetails struct {
 	ResolutionDetail
 }
 
-// GetBooleanValue return boolean evaluation for flag
-func (c Client) GetBooleanValue(flag string, defaultValue bool, evalCtx EvaluationContext, options ...EvaluationOption) (bool, error) {
-	resolution := api.provider.GetBooleanEvaluation(flag, defaultValue, evalCtx, options...)
+// BooleanValue return boolean evaluation for flag
+func (c Client) BooleanValue(flag string, defaultValue bool, evalCtx EvaluationContext, options ...EvaluationOption) (bool, error) {
+	resolution := api.provider.BooleanEvaluation(flag, defaultValue, evalCtx, options...)
 	value := resolution.Value
 	err := resolution.Error()
 	if err != nil {
@@ -75,9 +75,9 @@ func (c Client) GetBooleanValue(flag string, defaultValue bool, evalCtx Evaluati
 	return value, err
 }
 
-// GetStringValue return string evaluation for flag
-func (c Client) GetStringValue(flag string, defaultValue string, evalCtx EvaluationContext, options ...EvaluationOption) (string, error) {
-	resolution := api.provider.GetStringEvaluation(flag, defaultValue, evalCtx, options...)
+// StringValue return string evaluation for flag
+func (c Client) StringValue(flag string, defaultValue string, evalCtx EvaluationContext, options ...EvaluationOption) (string, error) {
+	resolution := api.provider.StringEvaluation(flag, defaultValue, evalCtx, options...)
 	value := resolution.Value
 	err := resolution.Error()
 	if err != nil {
@@ -86,9 +86,9 @@ func (c Client) GetStringValue(flag string, defaultValue string, evalCtx Evaluat
 	return value, err
 }
 
-// GetNumberValue return number evaluation for flag
-func (c Client) GetNumberValue(flag string, defaultValue float64, evalCtx EvaluationContext, options ...EvaluationOption) (float64, error) {
-	resolution := api.provider.GetNumberEvaluation(flag, defaultValue, evalCtx, options...)
+// NumberValue return number evaluation for flag
+func (c Client) NumberValue(flag string, defaultValue float64, evalCtx EvaluationContext, options ...EvaluationOption) (float64, error) {
+	resolution := api.provider.NumberEvaluation(flag, defaultValue, evalCtx, options...)
 	value := resolution.Value
 	err := resolution.Error()
 	if err != nil {
@@ -97,9 +97,9 @@ func (c Client) GetNumberValue(flag string, defaultValue float64, evalCtx Evalua
 	return value, err
 }
 
-// GetObjectValue return object evaluation for flag
-func (c Client) GetObjectValue(flag string, defaultValue interface{}, evalCtx EvaluationContext, options ...EvaluationOption) (interface{}, error) {
-	resolution := api.provider.GetObjectEvaluation(flag, defaultValue, evalCtx, options...)
+// ObjectValue return object evaluation for flag
+func (c Client) ObjectValue(flag string, defaultValue interface{}, evalCtx EvaluationContext, options ...EvaluationOption) (interface{}, error) {
+	resolution := api.provider.ObjectEvaluation(flag, defaultValue, evalCtx, options...)
 	value := resolution.Value
 	err := resolution.Error()
 	if err != nil {
@@ -108,17 +108,17 @@ func (c Client) GetObjectValue(flag string, defaultValue interface{}, evalCtx Ev
 	return value, err
 }
 
-// GetBooleanValueDetails return boolean evaluation for flag
-func (c Client) GetBooleanValueDetails(flag string, defaultValue bool, evalCtx EvaluationContext, options ...EvaluationOption) (EvaluationDetails, error) {
-	resolution := api.provider.GetBooleanEvaluation(flag, defaultValue, evalCtx, options...)
+// BooleanValueDetails return boolean evaluation for flag
+func (c Client) BooleanValueDetails(flag string, defaultValue bool, evalCtx EvaluationContext, options ...EvaluationOption) (EvaluationDetails, error) {
+	resolution := api.provider.BooleanEvaluation(flag, defaultValue, evalCtx, options...)
 	value := resolution.Value
 	err := resolution.Error()
 	if err != nil {
 		value = defaultValue
 	}
 	return EvaluationDetails{
-		FlagKey:          flag,
-		FlagType:         Boolean,
+		FlagKey:  flag,
+		FlagType: Boolean,
 		ResolutionDetail: ResolutionDetail{
 			Value:     value,
 			ErrorCode: resolution.ErrorCode,
@@ -129,17 +129,17 @@ func (c Client) GetBooleanValueDetails(flag string, defaultValue bool, evalCtx E
 
 }
 
-// GetStringValueDetails return string evaluation for flag
-func (c Client) GetStringValueDetails(flag string, defaultValue string, evalCtx EvaluationContext, options ...EvaluationOption) (EvaluationDetails, error) {
-	resolution := api.provider.GetStringEvaluation(flag, defaultValue, evalCtx, options...)
+// StringValueDetails return string evaluation for flag
+func (c Client) StringValueDetails(flag string, defaultValue string, evalCtx EvaluationContext, options ...EvaluationOption) (EvaluationDetails, error) {
+	resolution := api.provider.StringEvaluation(flag, defaultValue, evalCtx, options...)
 	value := resolution.Value
 	err := resolution.Error()
 	if err != nil {
 		value = defaultValue
 	}
 	return EvaluationDetails{
-		FlagKey:          flag,
-		FlagType:         String,
+		FlagKey:  flag,
+		FlagType: String,
 		ResolutionDetail: ResolutionDetail{
 			Value:     value,
 			ErrorCode: resolution.ErrorCode,
@@ -149,17 +149,17 @@ func (c Client) GetStringValueDetails(flag string, defaultValue string, evalCtx 
 	}, err
 }
 
-// GetNumberValueDetails return number evaluation for flag
-func (c Client) GetNumberValueDetails(flag string, defaultValue float64, evalCtx EvaluationContext, options ...EvaluationOption) (EvaluationDetails, error) {
-	resolution := api.provider.GetNumberEvaluation(flag, defaultValue, evalCtx, options...)
+// NumberValueDetails return number evaluation for flag
+func (c Client) NumberValueDetails(flag string, defaultValue float64, evalCtx EvaluationContext, options ...EvaluationOption) (EvaluationDetails, error) {
+	resolution := api.provider.NumberEvaluation(flag, defaultValue, evalCtx, options...)
 	value := resolution.Value
 	err := resolution.Error()
 	if err != nil {
 		value = defaultValue
 	}
 	return EvaluationDetails{
-		FlagKey:          flag,
-		FlagType:         Number,
+		FlagKey:  flag,
+		FlagType: Number,
 		ResolutionDetail: ResolutionDetail{
 			Value:     value,
 			ErrorCode: resolution.ErrorCode,
@@ -169,17 +169,17 @@ func (c Client) GetNumberValueDetails(flag string, defaultValue float64, evalCtx
 	}, err
 }
 
-// GetObjectValueDetails return object evaluation for flag
-func (c Client) GetObjectValueDetails(flag string, defaultValue interface{}, evalCtx EvaluationContext, options ...EvaluationOption) (EvaluationDetails, error) {
-	resolution := api.provider.GetObjectEvaluation(flag, defaultValue, evalCtx, options...)
+// ObjectValueDetails return object evaluation for flag
+func (c Client) ObjectValueDetails(flag string, defaultValue interface{}, evalCtx EvaluationContext, options ...EvaluationOption) (EvaluationDetails, error) {
+	resolution := api.provider.ObjectEvaluation(flag, defaultValue, evalCtx, options...)
 	value := resolution.Value
 	err := resolution.Error()
 	if err != nil {
 		value = defaultValue
 	}
 	return EvaluationDetails{
-		FlagKey:          flag,
-		FlagType:         Object,
+		FlagKey:  flag,
+		FlagType: Object,
 		ResolutionDetail: ResolutionDetail{
 			Value:     value,
 			ErrorCode: resolution.ErrorCode,

--- a/pkg/openfeature/client_example_test.go
+++ b/pkg/openfeature/client_example_test.go
@@ -14,9 +14,9 @@ func ExampleGetClient() {
 	// Output: Client Name: example-client
 }
 
-func ExampleClient_GetBooleanValue() {
+func ExampleClient_BooleanValue() {
 	client := openfeature.GetClient("example-client")
-	value, err := client.GetBooleanValue("test-flag", true, nil)
+	value, err := client.BooleanValue("test-flag", true, nil)
 	if err != nil {
 		log.Fatal("error while getting boolean value : ", err)
 	}
@@ -25,9 +25,9 @@ func ExampleClient_GetBooleanValue() {
 	// Output: test-flag value: true
 }
 
-func ExampleClient_GetStringValue() {
+func ExampleClient_StringValue() {
 	client := openfeature.GetClient("example-client")
-	value, err := client.GetStringValue("test-flag", "openfeature", nil)
+	value, err := client.StringValue("test-flag", "openfeature", nil)
 	if err != nil {
 		log.Fatal("error while getting string value : ", err)
 	}
@@ -36,9 +36,9 @@ func ExampleClient_GetStringValue() {
 	// Output: test-flag value: openfeature
 }
 
-func ExampleClient_GetNumberValue() {
+func ExampleClient_NumberValue() {
 	client := openfeature.GetClient("example-client")
-	value, err := client.GetNumberValue("test-flag", 0.55, nil)
+	value, err := client.NumberValue("test-flag", 0.55, nil)
 	if err != nil {
 		log.Fatal("error while getting number value : ", err)
 	}
@@ -47,9 +47,9 @@ func ExampleClient_GetNumberValue() {
 	// Output: test-flag value: 0.55
 }
 
-func ExampleClient_GetObjectValue() {
+func ExampleClient_ObjectValue() {
 	client := openfeature.GetClient("example-client")
-	value, err := client.GetObjectValue("test-flag", map[string]string{"foo": "bar"}, nil)
+	value, err := client.ObjectValue("test-flag", map[string]string{"foo": "bar"}, nil)
 	if err != nil {
 		log.Fatal("error while getting object value : ", err)
 	}

--- a/pkg/openfeature/client_test.go
+++ b/pkg/openfeature/client_test.go
@@ -1,8 +1,9 @@
 package openfeature
 
 import (
-	"github.com/golang/mock/gomock"
 	"testing"
+
+	"github.com/golang/mock/gomock"
 )
 
 func TestRequirement_1_2_1(t *testing.T) {
@@ -37,10 +38,10 @@ func TestRequirements_1_3(t *testing.T) {
 	client := GetClient("test-client")
 
 	type requirements interface {
-		GetBooleanValue(flag string, defaultValue bool, evalCtx EvaluationContext, options ...EvaluationOption) (bool, error)
-		GetStringValue(flag string, defaultValue string, evalCtx EvaluationContext, options ...EvaluationOption) (string, error)
-		GetNumberValue(flag string, defaultValue float64, evalCtx EvaluationContext, options ...EvaluationOption) (float64, error)
-		GetObjectValue(flag string, defaultValue interface{}, evalCtx EvaluationContext, options ...EvaluationOption) (interface{}, error)
+		BooleanValue(flag string, defaultValue bool, evalCtx EvaluationContext, options ...EvaluationOption) (bool, error)
+		StringValue(flag string, defaultValue string, evalCtx EvaluationContext, options ...EvaluationOption) (string, error)
+		NumberValue(flag string, defaultValue float64, evalCtx EvaluationContext, options ...EvaluationOption) (float64, error)
+		ObjectValue(flag string, defaultValue interface{}, evalCtx EvaluationContext, options ...EvaluationOption) (interface{}, error)
 	}
 
 	var clientI interface{} = client
@@ -54,10 +55,10 @@ func TestRequirement_1_4_1(t *testing.T) {
 	client := GetClient("test-client")
 
 	type requirements interface {
-		GetBooleanValueDetails(flag string, defaultValue bool, evalCtx EvaluationContext, options ...EvaluationOption) (EvaluationDetails, error)
-		GetStringValueDetails(flag string, defaultValue string, evalCtx EvaluationContext, options ...EvaluationOption) (EvaluationDetails, error)
-		GetNumberValueDetails(flag string, defaultValue float64, evalCtx EvaluationContext, options ...EvaluationOption) (EvaluationDetails, error)
-		GetObjectValueDetails(flag string, defaultValue interface{}, evalCtx EvaluationContext, options ...EvaluationOption) (EvaluationDetails, error)
+		BooleanValueDetails(flag string, defaultValue bool, evalCtx EvaluationContext, options ...EvaluationOption) (EvaluationDetails, error)
+		StringValueDetails(flag string, defaultValue string, evalCtx EvaluationContext, options ...EvaluationOption) (EvaluationDetails, error)
+		NumberValueDetails(flag string, defaultValue float64, evalCtx EvaluationContext, options ...EvaluationOption) (EvaluationDetails, error)
+		ObjectValueDetails(flag string, defaultValue interface{}, evalCtx EvaluationContext, options ...EvaluationOption) (EvaluationDetails, error)
 	}
 
 	var clientI interface{} = client
@@ -76,8 +77,8 @@ func TestRequirement_1_4_4(t *testing.T) {
 
 	flagKey := "foo"
 
-	t.Run("GetBooleanValueDetails", func(t *testing.T) {
-		evDetails, err := client.GetBooleanValueDetails(flagKey, true, nil)
+	t.Run("BooleanValueDetails", func(t *testing.T) {
+		evDetails, err := client.BooleanValueDetails(flagKey, true, nil)
 		if err != nil {
 			t.Error(err)
 		}
@@ -89,8 +90,8 @@ func TestRequirement_1_4_4(t *testing.T) {
 		}
 	})
 
-	t.Run("GetStringValueDetails", func(t *testing.T) {
-		evDetails, err := client.GetStringValueDetails(flagKey, "", nil)
+	t.Run("StringValueDetails", func(t *testing.T) {
+		evDetails, err := client.StringValueDetails(flagKey, "", nil)
 		if err != nil {
 			t.Error(err)
 		}
@@ -102,8 +103,8 @@ func TestRequirement_1_4_4(t *testing.T) {
 		}
 	})
 
-	t.Run("GetNumberValueDetails", func(t *testing.T) {
-		evDetails, err := client.GetNumberValueDetails(flagKey, 1, nil)
+	t.Run("NumberValueDetails", func(t *testing.T) {
+		evDetails, err := client.NumberValueDetails(flagKey, 1, nil)
 		if err != nil {
 			t.Error(err)
 		}
@@ -115,8 +116,8 @@ func TestRequirement_1_4_4(t *testing.T) {
 		}
 	})
 
-	t.Run("GetObjectValueDetails", func(t *testing.T) {
-		evDetails, err := client.GetObjectValueDetails(flagKey, 1, nil)
+	t.Run("ObjectValueDetails", func(t *testing.T) {
+		evDetails, err := client.ObjectValueDetails(flagKey, 1, nil)
 		if err != nil {
 			t.Error(err)
 		}
@@ -150,32 +151,32 @@ func TestRequirement_1_4_9(t *testing.T) {
 		defer t.Cleanup(initSingleton)
 		mockProvider := NewMockFeatureProvider(ctrl)
 		defaultValue := true
-		mockProvider.EXPECT().GetBooleanEvaluation(flagKey, defaultValue, nil).Return(BoolResolutionDetail{
-			Value:            false,
+		mockProvider.EXPECT().BooleanEvaluation(flagKey, defaultValue, nil).Return(BoolResolutionDetail{
+			Value: false,
 			ResolutionDetail: ResolutionDetail{
-				Value: false,
+				Value:     false,
 				ErrorCode: "GENERAL",
-				Reason: "forced test error",
+				Reason:    "forced test error",
 			},
 		}).Times(2)
 		SetProvider(mockProvider)
 
-		value, err := client.GetBooleanValue(flagKey, defaultValue, nil)
+		value, err := client.BooleanValue(flagKey, defaultValue, nil)
 		if err == nil {
-			t.Error("expected GetBooleanValue to return an error, got nil")
+			t.Error("expected BooleanValue to return an error, got nil")
 		}
 
 		if value != defaultValue {
-			t.Errorf("expected default value from GetBooleanValue, got %v", value)
+			t.Errorf("expected default value from BooleanValue, got %v", value)
 		}
 
-		valueDetails, err := client.GetBooleanValueDetails(flagKey, defaultValue, nil)
+		valueDetails, err := client.BooleanValueDetails(flagKey, defaultValue, nil)
 		if err == nil {
-			t.Error("expected GetBooleanValueDetails to return an error, got nil")
+			t.Error("expected BooleanValueDetails to return an error, got nil")
 		}
 
 		if valueDetails.Value.(bool) != defaultValue {
-			t.Errorf("expected default value from GetBooleanValueDetails, got %v", value)
+			t.Errorf("expected default value from BooleanValueDetails, got %v", value)
 		}
 	})
 
@@ -183,32 +184,32 @@ func TestRequirement_1_4_9(t *testing.T) {
 		defer t.Cleanup(initSingleton)
 		mockProvider := NewMockFeatureProvider(ctrl)
 		defaultValue := "default"
-		mockProvider.EXPECT().GetStringEvaluation(flagKey, defaultValue, nil).Return(StringResolutionDetail{
-			Value:            "foo",
+		mockProvider.EXPECT().StringEvaluation(flagKey, defaultValue, nil).Return(StringResolutionDetail{
+			Value: "foo",
 			ResolutionDetail: ResolutionDetail{
-				Value: "foo",
+				Value:     "foo",
 				ErrorCode: "GENERAL",
-				Reason: "forced test error",
+				Reason:    "forced test error",
 			},
 		}).Times(2)
 		SetProvider(mockProvider)
 
-		value, err := client.GetStringValue(flagKey, defaultValue, nil)
+		value, err := client.StringValue(flagKey, defaultValue, nil)
 		if err == nil {
-			t.Error("expected GetStringValue to return an error, got nil")
+			t.Error("expected StringValue to return an error, got nil")
 		}
 
 		if value != defaultValue {
-			t.Errorf("expected default value from GetStringValue, got %v", value)
+			t.Errorf("expected default value from StringValue, got %v", value)
 		}
 
-		valueDetails, err := client.GetStringValueDetails(flagKey, defaultValue, nil)
+		valueDetails, err := client.StringValueDetails(flagKey, defaultValue, nil)
 		if err == nil {
-			t.Error("expected GetStringValueDetails to return an error, got nil")
+			t.Error("expected StringValueDetails to return an error, got nil")
 		}
 
 		if valueDetails.Value.(string) != defaultValue {
-			t.Errorf("expected default value from GetStringValueDetails, got %v", value)
+			t.Errorf("expected default value from StringValueDetails, got %v", value)
 		}
 	})
 
@@ -216,32 +217,32 @@ func TestRequirement_1_4_9(t *testing.T) {
 		defer t.Cleanup(initSingleton)
 		mockProvider := NewMockFeatureProvider(ctrl)
 		defaultValue := 3.14159
-		mockProvider.EXPECT().GetNumberEvaluation(flagKey, defaultValue, nil).Return(NumberResolutionDetail{
-			Value:            0,
+		mockProvider.EXPECT().NumberEvaluation(flagKey, defaultValue, nil).Return(NumberResolutionDetail{
+			Value: 0,
 			ResolutionDetail: ResolutionDetail{
-				Value: 0,
+				Value:     0,
 				ErrorCode: "GENERAL",
-				Reason: "forced test error",
+				Reason:    "forced test error",
 			},
 		}).Times(2)
 		SetProvider(mockProvider)
 
-		value, err := client.GetNumberValue(flagKey, defaultValue, nil)
+		value, err := client.NumberValue(flagKey, defaultValue, nil)
 		if err == nil {
-			t.Error("expected GetNumberValue to return an error, got nil")
+			t.Error("expected NumberValue to return an error, got nil")
 		}
 
 		if value != defaultValue {
-			t.Errorf("expected default value from GetNumberValue, got %v", value)
+			t.Errorf("expected default value from NumberValue, got %v", value)
 		}
 
-		valueDetails, err := client.GetNumberValueDetails(flagKey, defaultValue, nil)
+		valueDetails, err := client.NumberValueDetails(flagKey, defaultValue, nil)
 		if err == nil {
-			t.Error("expected GetNumberValueDetails to return an error, got nil")
+			t.Error("expected NumberValueDetails to return an error, got nil")
 		}
 
 		if valueDetails.Value.(float64) != defaultValue {
-			t.Errorf("expected default value from GetNumberValueDetails, got %v", value)
+			t.Errorf("expected default value from NumberValueDetails, got %v", value)
 		}
 	})
 
@@ -252,29 +253,29 @@ func TestRequirement_1_4_9(t *testing.T) {
 			foo string
 		}
 		defaultValue := obj{foo: "bar"}
-		mockProvider.EXPECT().GetObjectEvaluation(flagKey, defaultValue, nil).Return(ResolutionDetail{
-			Value: obj{foo: "foo"},
+		mockProvider.EXPECT().ObjectEvaluation(flagKey, defaultValue, nil).Return(ResolutionDetail{
+			Value:     obj{foo: "foo"},
 			ErrorCode: "GENERAL",
-			Reason: "forced test error",
+			Reason:    "forced test error",
 		}).Times(2)
 		SetProvider(mockProvider)
 
-		value, err := client.GetObjectValue(flagKey, defaultValue, nil)
+		value, err := client.ObjectValue(flagKey, defaultValue, nil)
 		if err == nil {
-			t.Error("expected GetObjectValue to return an error, got nil")
+			t.Error("expected ObjectValue to return an error, got nil")
 		}
 
 		if value != defaultValue {
-			t.Errorf("expected default value from GetObjectValue, got %v", value)
+			t.Errorf("expected default value from ObjectValue, got %v", value)
 		}
 
-		valueDetails, err := client.GetObjectValueDetails(flagKey, defaultValue, nil)
+		valueDetails, err := client.ObjectValueDetails(flagKey, defaultValue, nil)
 		if err == nil {
-			t.Error("expected GetObjectValueDetails to return an error, got nil")
+			t.Error("expected ObjectValueDetails to return an error, got nil")
 		}
 
 		if valueDetails.Value.(obj) != defaultValue {
-			t.Errorf("expected default value from GetObjectValueDetails, got %v", value)
+			t.Errorf("expected default value from ObjectValueDetails, got %v", value)
 		}
 	})
 }

--- a/pkg/openfeature/noop_provider.go
+++ b/pkg/openfeature/noop_provider.go
@@ -8,8 +8,8 @@ func (e NoopProvider) Metadata() Metadata {
 	return Metadata{Name: "NoopProvider"}
 }
 
-// GetBooleanEvaluation returns a boolean flag.
-func (e NoopProvider) GetBooleanEvaluation(flag string, defaultValue bool, evalCtx EvaluationContext, options ...EvaluationOption) BoolResolutionDetail {
+// BooleanEvaluation returns a boolean flag.
+func (e NoopProvider) BooleanEvaluation(flag string, defaultValue bool, evalCtx EvaluationContext, options ...EvaluationOption) BoolResolutionDetail {
 	return BoolResolutionDetail{
 		Value: defaultValue,
 		ResolutionDetail: ResolutionDetail{
@@ -19,8 +19,8 @@ func (e NoopProvider) GetBooleanEvaluation(flag string, defaultValue bool, evalC
 	}
 }
 
-// GetStringEvaluation returns a string flag.
-func (e NoopProvider) GetStringEvaluation(flag string, defaultValue string, evalCtx EvaluationContext, options ...EvaluationOption) StringResolutionDetail {
+// StringEvaluation returns a string flag.
+func (e NoopProvider) StringEvaluation(flag string, defaultValue string, evalCtx EvaluationContext, options ...EvaluationOption) StringResolutionDetail {
 	return StringResolutionDetail{
 		Value: defaultValue,
 		ResolutionDetail: ResolutionDetail{
@@ -30,8 +30,8 @@ func (e NoopProvider) GetStringEvaluation(flag string, defaultValue string, eval
 	}
 }
 
-// GetNumberEvaluation returns a number flag.
-func (e NoopProvider) GetNumberEvaluation(flag string, defaultValue float64, evalCtx EvaluationContext, options ...EvaluationOption) NumberResolutionDetail {
+// NumberEvaluation returns a number flag.
+func (e NoopProvider) NumberEvaluation(flag string, defaultValue float64, evalCtx EvaluationContext, options ...EvaluationOption) NumberResolutionDetail {
 	return NumberResolutionDetail{
 		Value: defaultValue,
 		ResolutionDetail: ResolutionDetail{
@@ -41,8 +41,8 @@ func (e NoopProvider) GetNumberEvaluation(flag string, defaultValue float64, eva
 	}
 }
 
-// GetObjectEvaluation returns an object flag
-func (e NoopProvider) GetObjectEvaluation(flag string, defaultValue interface{}, evalCtx EvaluationContext, options ...EvaluationOption) ResolutionDetail {
+// ObjectEvaluation returns an object flag
+func (e NoopProvider) ObjectEvaluation(flag string, defaultValue interface{}, evalCtx EvaluationContext, options ...EvaluationOption) ResolutionDetail {
 	return ResolutionDetail{
 		Value:   defaultValue,
 		Variant: "default-variant",

--- a/pkg/openfeature/provider.go
+++ b/pkg/openfeature/provider.go
@@ -14,10 +14,10 @@ const (
 // vendors should implement
 type FeatureProvider interface {
 	Metadata() Metadata
-	GetBooleanEvaluation(flag string, defaultValue bool, evalCtx EvaluationContext, options ...EvaluationOption) BoolResolutionDetail
-	GetStringEvaluation(flag string, defaultValue string, evalCtx EvaluationContext, options ...EvaluationOption) StringResolutionDetail
-	GetNumberEvaluation(flag string, defaultValue float64, evalCtx EvaluationContext, options ...EvaluationOption) NumberResolutionDetail
-	GetObjectEvaluation(flag string, defaultValue interface{}, evalCtx EvaluationContext, options ...EvaluationOption) ResolutionDetail
+	BooleanEvaluation(flag string, defaultValue bool, evalCtx EvaluationContext, options ...EvaluationOption) BoolResolutionDetail
+	StringEvaluation(flag string, defaultValue string, evalCtx EvaluationContext, options ...EvaluationOption) StringResolutionDetail
+	NumberEvaluation(flag string, defaultValue float64, evalCtx EvaluationContext, options ...EvaluationOption) NumberResolutionDetail
+	ObjectEvaluation(flag string, defaultValue interface{}, evalCtx EvaluationContext, options ...EvaluationOption) ResolutionDetail
 }
 
 // ResolutionDetail is a structure which contains a subset of the fields defined in the EvaluationDetail,

--- a/pkg/openfeature/provider_mock_test.go
+++ b/pkg/openfeature/provider_mock_test.go
@@ -33,80 +33,80 @@ func (m *MockFeatureProvider) EXPECT() *MockFeatureProviderMockRecorder {
 	return m.recorder
 }
 
-// GetBooleanEvaluation mocks base method.
-func (m *MockFeatureProvider) GetBooleanEvaluation(flag string, defaultValue bool, evalCtx EvaluationContext, options ...EvaluationOption) BoolResolutionDetail {
+// BooleanEvaluation mocks base method.
+func (m *MockFeatureProvider) BooleanEvaluation(flag string, defaultValue bool, evalCtx EvaluationContext, options ...EvaluationOption) BoolResolutionDetail {
 	m.ctrl.T.Helper()
 	varargs := []interface{}{flag, defaultValue, evalCtx}
 	for _, a := range options {
 		varargs = append(varargs, a)
 	}
-	ret := m.ctrl.Call(m, "GetBooleanEvaluation", varargs...)
+	ret := m.ctrl.Call(m, "BooleanEvaluation", varargs...)
 	ret0, _ := ret[0].(BoolResolutionDetail)
 	return ret0
 }
 
-// GetBooleanEvaluation indicates an expected call of GetBooleanEvaluation.
-func (mr *MockFeatureProviderMockRecorder) GetBooleanEvaluation(flag, defaultValue, evalCtx interface{}, options ...interface{}) *gomock.Call {
+// BooleanEvaluation indicates an expected call of BooleanEvaluation.
+func (mr *MockFeatureProviderMockRecorder) BooleanEvaluation(flag, defaultValue, evalCtx interface{}, options ...interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{flag, defaultValue, evalCtx}, options...)
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetBooleanEvaluation", reflect.TypeOf((*MockFeatureProvider)(nil).GetBooleanEvaluation), varargs...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BooleanEvaluation", reflect.TypeOf((*MockFeatureProvider)(nil).BooleanEvaluation), varargs...)
 }
 
-// GetNumberEvaluation mocks base method.
-func (m *MockFeatureProvider) GetNumberEvaluation(flag string, defaultValue float64, evalCtx EvaluationContext, options ...EvaluationOption) NumberResolutionDetail {
+// NumberEvaluation mocks base method.
+func (m *MockFeatureProvider) NumberEvaluation(flag string, defaultValue float64, evalCtx EvaluationContext, options ...EvaluationOption) NumberResolutionDetail {
 	m.ctrl.T.Helper()
 	varargs := []interface{}{flag, defaultValue, evalCtx}
 	for _, a := range options {
 		varargs = append(varargs, a)
 	}
-	ret := m.ctrl.Call(m, "GetNumberEvaluation", varargs...)
+	ret := m.ctrl.Call(m, "NumberEvaluation", varargs...)
 	ret0, _ := ret[0].(NumberResolutionDetail)
 	return ret0
 }
 
-// GetNumberEvaluation indicates an expected call of GetNumberEvaluation.
-func (mr *MockFeatureProviderMockRecorder) GetNumberEvaluation(flag, defaultValue, evalCtx interface{}, options ...interface{}) *gomock.Call {
+// NumberEvaluation indicates an expected call of NumberEvaluation.
+func (mr *MockFeatureProviderMockRecorder) NumberEvaluation(flag, defaultValue, evalCtx interface{}, options ...interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{flag, defaultValue, evalCtx}, options...)
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetNumberEvaluation", reflect.TypeOf((*MockFeatureProvider)(nil).GetNumberEvaluation), varargs...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NumberEvaluation", reflect.TypeOf((*MockFeatureProvider)(nil).NumberEvaluation), varargs...)
 }
 
-// GetObjectEvaluation mocks base method.
-func (m *MockFeatureProvider) GetObjectEvaluation(flag string, defaultValue interface{}, evalCtx EvaluationContext, options ...EvaluationOption) ResolutionDetail {
+// ObjectEvaluation mocks base method.
+func (m *MockFeatureProvider) ObjectEvaluation(flag string, defaultValue interface{}, evalCtx EvaluationContext, options ...EvaluationOption) ResolutionDetail {
 	m.ctrl.T.Helper()
 	varargs := []interface{}{flag, defaultValue, evalCtx}
 	for _, a := range options {
 		varargs = append(varargs, a)
 	}
-	ret := m.ctrl.Call(m, "GetObjectEvaluation", varargs...)
+	ret := m.ctrl.Call(m, "ObjectEvaluation", varargs...)
 	ret0, _ := ret[0].(ResolutionDetail)
 	return ret0
 }
 
-// GetObjectEvaluation indicates an expected call of GetObjectEvaluation.
-func (mr *MockFeatureProviderMockRecorder) GetObjectEvaluation(flag, defaultValue, evalCtx interface{}, options ...interface{}) *gomock.Call {
+// ObjectEvaluation indicates an expected call of ObjectEvaluation.
+func (mr *MockFeatureProviderMockRecorder) ObjectEvaluation(flag, defaultValue, evalCtx interface{}, options ...interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{flag, defaultValue, evalCtx}, options...)
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetObjectEvaluation", reflect.TypeOf((*MockFeatureProvider)(nil).GetObjectEvaluation), varargs...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ObjectEvaluation", reflect.TypeOf((*MockFeatureProvider)(nil).ObjectEvaluation), varargs...)
 }
 
-// GetStringEvaluation mocks base method.
-func (m *MockFeatureProvider) GetStringEvaluation(flag, defaultValue string, evalCtx EvaluationContext, options ...EvaluationOption) StringResolutionDetail {
+// StringEvaluation mocks base method.
+func (m *MockFeatureProvider) StringEvaluation(flag, defaultValue string, evalCtx EvaluationContext, options ...EvaluationOption) StringResolutionDetail {
 	m.ctrl.T.Helper()
 	varargs := []interface{}{flag, defaultValue, evalCtx}
 	for _, a := range options {
 		varargs = append(varargs, a)
 	}
-	ret := m.ctrl.Call(m, "GetStringEvaluation", varargs...)
+	ret := m.ctrl.Call(m, "StringEvaluation", varargs...)
 	ret0, _ := ret[0].(StringResolutionDetail)
 	return ret0
 }
 
-// GetStringEvaluation indicates an expected call of GetStringEvaluation.
-func (mr *MockFeatureProviderMockRecorder) GetStringEvaluation(flag, defaultValue, evalCtx interface{}, options ...interface{}) *gomock.Call {
+// StringEvaluation indicates an expected call of StringEvaluation.
+func (mr *MockFeatureProviderMockRecorder) StringEvaluation(flag, defaultValue, evalCtx interface{}, options ...interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{flag, defaultValue, evalCtx}, options...)
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetStringEvaluation", reflect.TypeOf((*MockFeatureProvider)(nil).GetStringEvaluation), varargs...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StringEvaluation", reflect.TypeOf((*MockFeatureProvider)(nil).StringEvaluation), varargs...)
 }
 
 // Metadata mocks base method.

--- a/pkg/openfeature/provider_test.go
+++ b/pkg/openfeature/provider_test.go
@@ -36,10 +36,10 @@ func TestRequirement_2_2(t *testing.T) {
 	mockProvider := NewMockFeatureProvider(ctrl)
 
 	type requirements interface {
-		GetBooleanEvaluation(flag string, defaultValue bool, evalCtx EvaluationContext, options ...EvaluationOption) BoolResolutionDetail
-		GetStringEvaluation(flag string, defaultValue string, evalCtx EvaluationContext, options ...EvaluationOption) StringResolutionDetail
-		GetNumberEvaluation(flag string, defaultValue float64, evalCtx EvaluationContext, options ...EvaluationOption) NumberResolutionDetail
-		GetObjectEvaluation(flag string, defaultValue interface{}, evalCtx EvaluationContext, options ...EvaluationOption) ResolutionDetail
+		BooleanEvaluation(flag string, defaultValue bool, evalCtx EvaluationContext, options ...EvaluationOption) BoolResolutionDetail
+		StringEvaluation(flag string, defaultValue string, evalCtx EvaluationContext, options ...EvaluationOption) StringResolutionDetail
+		NumberEvaluation(flag string, defaultValue float64, evalCtx EvaluationContext, options ...EvaluationOption) NumberResolutionDetail
+		ObjectEvaluation(flag string, defaultValue interface{}, evalCtx EvaluationContext, options ...EvaluationOption) ResolutionDetail
 	}
 
 	var mockProviderI interface{} = mockProvider


### PR DESCRIPTION
### Why

Rename getters to be more inline with Golang idioms. Close #22

### What changed

16 functions were edited in these files. `GetClient()` is the only function that cannot be edited, else it will conflict with `Client` struct in the code.
