### PR TITLE
Updated HookContext to be passed as a pointer

### DIFF
--- a/pkg/openfeature/hooks.go
+++ b/pkg/openfeature/hooks.go
@@ -4,10 +4,10 @@ package openfeature
 // They operate similarly to middleware in many web frameworks.
 // https://github.com/open-feature/spec/blob/main/specification/hooks.md
 type Hook interface {
-	Before(hookContext HookContext, hookHints HookHints) (*EvaluationContext, error)
-	After(hookContext HookContext, flagEvaluationDetails EvaluationDetails, hookHints HookHints) error
-	Error(hookContext HookContext, err error, hookHints HookHints)
-	Finally(hookContext HookContext, hookHints HookHints)
+	Before(hookContext *HookContext, hookHints HookHints) (*EvaluationContext, error)
+	After(hookContext *HookContext, flagEvaluationDetails EvaluationDetails, hookHints HookHints) error
+	Error(hookContext *HookContext, err error, hookHints HookHints)
+	Finally(hookContext *HookContext, hookHints HookHints)
 }
 
 // HookHints contains a map of hints for hooks
@@ -34,6 +34,9 @@ type HookContext struct {
 	clientMetadata    ClientMetadata
 	providerMetadata  Metadata
 	evaluationContext EvaluationContext
+	// Store provides a persistent state across Hook methods (Before, After, Finally, Error).
+	// This is shared between all hooks so it is strongly advised to use a hook specific prefix.
+	Store map[string]interface{}
 }
 
 // FlagKey returns the hook context's flag key

--- a/pkg/openfeature/hooks_mock_test.go
+++ b/pkg/openfeature/hooks_mock_test.go
@@ -34,7 +34,7 @@ func (m *MockHook) EXPECT() *MockHookMockRecorder {
 }
 
 // After mocks base method.
-func (m *MockHook) After(hookContext HookContext, flagEvaluationDetails EvaluationDetails, hookHints HookHints) error {
+func (m *MockHook) After(hookContext *HookContext, flagEvaluationDetails EvaluationDetails, hookHints HookHints) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "After", hookContext, flagEvaluationDetails, hookHints)
 	ret0, _ := ret[0].(error)
@@ -48,7 +48,7 @@ func (mr *MockHookMockRecorder) After(hookContext, flagEvaluationDetails, hookHi
 }
 
 // Before mocks base method.
-func (m *MockHook) Before(hookContext HookContext, hookHints HookHints) (*EvaluationContext, error) {
+func (m *MockHook) Before(hookContext *HookContext, hookHints HookHints) (*EvaluationContext, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Before", hookContext, hookHints)
 	ret0, _ := ret[0].(*EvaluationContext)
@@ -63,7 +63,7 @@ func (mr *MockHookMockRecorder) Before(hookContext, hookHints interface{}) *gomo
 }
 
 // Error mocks base method.
-func (m *MockHook) Error(hookContext HookContext, err error, hookHints HookHints) {
+func (m *MockHook) Error(hookContext *HookContext, err error, hookHints HookHints) {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "Error", hookContext, err, hookHints)
 }
@@ -75,7 +75,7 @@ func (mr *MockHookMockRecorder) Error(hookContext, err, hookHints interface{}) *
 }
 
 // Finally mocks base method.
-func (m *MockHook) Finally(hookContext HookContext, hookHints HookHints) {
+func (m *MockHook) Finally(hookContext *HookContext, hookHints HookHints) {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "Finally", hookContext, hookHints)
 }


### PR DESCRIPTION
Currently each method (`Before`, `After`, `Finally` and `Error`) is called on a copy of any given 'Hook' struct, with the `hookCtx` argument being passed by value. This means that across the lifecycle of a hook there is no opportunity for persisting state between these methods, excluding overloading the `EvaluationContext`.

An example of where this persistence is important is in the implementation of the open-telemetry hook. For this hook to work a `span` needs to be created in the before hook, and attributes set in any of the downstream methods. With the current implementation this  is not possible.

This draft PR contains a proposed approach for allowing state to be carried across the hooks lifecycle.
`HookContext` is now passed as a pointer and contains the `Store` field (Would appreciate some input on this name), this means that all `Hooks` now have access to a single shared `map[string]interface{}`.

Another approach that could be taken to achieve the same outcome is for each Hook to be treated as a singleton, at which point state can be managed internally.