### PR TITLE
fix: return error code from client given by provider

### DIFF
--- a/pkg/openfeature/client.go
+++ b/pkg/openfeature/client.go
@@ -303,6 +303,7 @@ func (c Client) evaluate(
 		)
 		err = fmt.Errorf("error code: %w", err)
 		c.errorHooks(hookCtx, providerInvocationClientApiHooks, err, options)
+		evalDetails.InterfaceResolutionDetail.ResolutionDetail = resolution.ResolutionDetail
 		return evalDetails, err
 	}
 	if resolution.Value != nil {


### PR DESCRIPTION
[Requirement 147 of the spec says that the error code must be provided upon abnormal execution](https://docs.openfeature.dev/docs/specification/sections/flag-evaluation#requirement-147). The current setup returns an `EvaluationDetails` with no error code, regardless of what error code the Provider returned.
This populates the `ResolutionDetail` of the return value with the error code, reason, and variant values returned by the provider.
Since this just populates the `ResolutionDetail` and not the `InterfaceResolutionDetail`, the default treatment will remain the value regardless of what the provider returned.